### PR TITLE
Fix textfield height for outdated browsers

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -136,6 +136,7 @@ dialog::backdrop {
 body {
     display: flex;
     flex-direction: column;
+    height: 100vh;
     height: 100dvh;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
See https://caniuse.com/viewport-unit-variants
Thanks to Daedalus for suggesting the fix.

Broke on my old Microsoft Edge 92.0.902.67 that was pre-installed on a Win10 22H2 testing system.

For personal reasons, I just use this windows installation to reverse engineer a program only available on windows, obviously, I don't use this trash OS for anything else lel